### PR TITLE
fix: use the 'tar' filter to remove warnings

### DIFF
--- a/.changeset/rotten-dolls-relate.md
+++ b/.changeset/rotten-dolls-relate.md
@@ -1,0 +1,5 @@
+---
+'app': patch
+---
+
+Update the OIDC Sign-in Page Title

--- a/docker/install-dynamic-plugins.py
+++ b/docker/install-dynamic-plugins.py
@@ -268,7 +268,7 @@ def main():
                 if not realpath.startswith(directoryRealpath):
                   raise InstallException('NPM package archive contains a link outside of the archive: ' + member.name + ' -> ' + member.linkpath)
 
-                file.extract(member, path=directory)
+                file.extract(member, path=directory, filter='tar')
             else:
               if member.type == tarfile.CHRTYPE:
                   type_str = "character device"

--- a/docker/install-dynamic-plugins.py
+++ b/docker/install-dynamic-plugins.py
@@ -29,7 +29,7 @@ import binascii
 # the dynamic plugins will be installed.
 #
 # Additionally, the MAX_ENTRY_SIZE environment variable can be defined to set
-# the maximum size of a file in the archive (default: 10MB).
+# the maximum size of a file in the archive (default: 20MB).
 #
 # The SKIP_INTEGRITY_CHECK environment variable can be defined with ("true") to skip the integrity check of remote packages
 #
@@ -112,7 +112,7 @@ def verify_package_integrity(plugin: dict, archive: str, working_directory: str)
 
 def main():
     dynamicPluginsRoot = sys.argv[1]
-    maxEntrySize = int(os.environ.get('MAX_ENTRY_SIZE', 10000000))
+    maxEntrySize = int(os.environ.get('MAX_ENTRY_SIZE', 20000000))
     skipIntegrityCheck = os.environ.get("SKIP_INTEGRITY_CHECK", "").lower() == "true"
 
     dynamicPluginsFile = 'dynamic-plugins.yaml'

--- a/packages/app/src/components/SignInPage/SignInPage.tsx
+++ b/packages/app/src/components/SignInPage/SignInPage.tsx
@@ -112,7 +112,7 @@ const PROVIDERS = new Map<string, SignInProviderConfig | string>([
     'oidc',
     {
       id: 'oidc-auth-provider',
-      title: 'Auth0',
+      title: 'OIDC',
       message: 'Sign in using OIDC',
       apiRef: oidcAuthApiRef,
     },


### PR DESCRIPTION
## Description

Since recently on both docker images, which have been updated, the following warning is displayed in the initContainer logs during dynamic plugins installation:
```
==> Extracting package archive /dynamic-plugins-root/janus-idp-backstage-plugin-topology-1.16.4.tgz
/usr/lib64/python3.9/tarfile.py:2239: RuntimeWarning: The default behavior of tarfile extraction has been changed to disallow common exploits (including CVE-2007-4559). By default, absolute/parent paths are disallowed and some mode bits are cleared. See https://access.redhat.com/articles/7004769 for more details.
```

This is because a new `filter` option option has been added in the python `tar` library, whose default value changes the default behavior of the library.

Explicitely setting this filter option to `tar` (which is the new default) should remove the warning from the logs.

## Which issue(s) does this PR fix

No issue

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
