### PR TITLE
feat(app) RHIDP-2338 expose dynamic UI config

### DIFF
--- a/packages/app/src/components/DynamicRoot/DynamicRootContext.tsx
+++ b/packages/app/src/components/DynamicRoot/DynamicRootContext.tsx
@@ -20,15 +20,6 @@ export type DynamicModuleEntry = Pick<
   ScalprumComponentProps,
   'scope' | 'module'
 >;
-export type DynamicRootContextValue = DynamicModuleEntry & {
-  path: string;
-  menuItem?: MenuItem;
-  Component: React.ComponentType<any>;
-  staticJSXContent?: React.ReactNode;
-  config: {
-    props?: Record<string, any>;
-  };
-};
 
 type ScalprumMountPointConfigBase = {
   layout?: Record<string, string>;
@@ -74,19 +65,41 @@ export type RemotePlugins = {
   };
 };
 
+export type DynamicRoute = DynamicModuleEntry & {
+  path: string;
+  menuItem?: MenuItem;
+  Component: React.ComponentType<any>;
+  staticJSXContent?: React.ReactNode;
+  config: {
+    props?: Record<string, any>;
+  };
+};
+
+export type EntityTabOverrides = Record<
+  string,
+  { title: string; mountPoint: string }
+>;
+
+export type MountPoints = Record<string, ScalprumMountPoint[]>;
+
+export type ScaffolderFieldExtension = {
+  scope: string;
+  module: string;
+  importName: string;
+  Component: React.ComponentType<{}>;
+};
+
+export type DynamicRootConfig = {
+  dynamicRoutes: DynamicRoute[];
+  entityTabOverrides: EntityTabOverrides;
+  mountPoints: MountPoints;
+  scaffolderFieldExtensions: ScaffolderFieldExtension[];
+};
+
 export type ComponentRegistry = {
   AppProvider: React.ComponentType<React.PropsWithChildren>;
   AppRouter: React.ComponentType<React.PropsWithChildren>;
-  dynamicRoutes: DynamicRootContextValue[];
-  entityTabOverrides: Record<string, { title: string; mountPoint: string }>;
-  mountPoints: { [mountPoint: string]: ScalprumMountPoint[] };
-  scaffolderFieldExtensions: {
-    scope: string;
-    module: string;
-    importName: string;
-    Component: React.ComponentType<{}>;
-  }[];
-};
+} & DynamicRootConfig;
 
 const DynamicRootContext = createContext<ComponentRegistry>({
   AppProvider: () => null,

--- a/packages/app/src/components/DynamicRoot/ScalprumRoot.tsx
+++ b/packages/app/src/components/DynamicRoot/ScalprumRoot.tsx
@@ -13,6 +13,7 @@ import Loader from './Loader';
 import { AppConfig } from '@backstage/config';
 import { DynamicRoot, StaticPlugins } from './DynamicRoot';
 import { DynamicPluginConfig } from '../../utils/dynamicUI/extractDynamicConfig';
+import { DynamicRootConfig } from './DynamicRootContext';
 
 const ScalprumRoot = ({
   apis,
@@ -65,8 +66,10 @@ const ScalprumRoot = ({
     return <Loader />;
   }
   const { dynamicPlugins, baseUrl, scalprumConfig } = value || {};
+  const apiHolder = {} as DynamicRootConfig;
   return (
-    <ScalprumProvider
+    <ScalprumProvider<DynamicRootConfig>
+      api={apiHolder}
       config={scalprumConfig ?? {}}
       pluginSDKOptions={{
         pluginLoaderOptions: {


### PR DESCRIPTION
Please explain the changes you made here.

This change exposes the dynamic UI configuration to dynamic plugins via
the scalprum API holder available with the scalprum React API.  This
change also moves around some blocks for consistency and improves the
typing for the DynamicRootContext objects.

- Fixes [RHIDP-2338](https://issues.redhat.com/browse/RHIDP-2338)

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
